### PR TITLE
Chore: Setup Email Config

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,6 @@ BASE_URL=http://localhost:8000
 
 MSAL_CLIENT_ID=
 MSAL_CLIENT_SECRET=
+
+EMAIL_HOST_USER=death.notes.uog@gmail.com
+EMAIL_HOST_PASSWORD=

--- a/death_notes/settings.py
+++ b/death_notes/settings.py
@@ -197,3 +197,18 @@ MSAL_CLIENT_SECRET = config('MSAL_CLIENT_SECRET')
 MSAL_AUTHORITY = config(
     'MSAL_AUTHORITY', default='https://login.microsoftonline.com/common'
 )
+
+
+# Email Configuration
+
+EMAIL_BACKEND = (
+    'django.core.mail.backends.console.EmailBackend'
+    if DEBUG
+    else 'django.core.mail.backends.smtp.EmailBackend'
+)
+EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_PORT = 587
+EMAIL_USE_TLS = True
+EMAIL_HOST_USER = config('EMAIL_HOST_USER')
+EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD')
+EMAIL_TIMEOUT = 5


### PR DESCRIPTION
This pull request includes changes to add email configuration settings to the project. The most important changes include updating the `.env` file to add email credentials and modifying the `settings.py` file to configure the email backend

```python3
from django.conf import settings
from django.core.mail import send_mail


send_mail(
    subject='Test Subject',
    message='Hello, this is a test email from Django!',
    from_email=settings.EMAIL_HOST_USER,
    recipient_list=['siddharthapdutta@gmail.com'],
)
```

Email configuration updates:

* [`.env`](diffhunk://#diff-e9cbb0224c4a3d23a6019ba557e0cd568c1ad5e1582ff1e335fb7d99b7a1055dR5-R7): Added `EMAIL_HOST_USER` and `EMAIL_HOST_PASSWORD` environment variables.
* [`death_notes/settings.py`](diffhunk://#diff-7f60bd6b74c6a650f4f56a44c0c9f69d6636b20fa05df89b9a753c99a0a5f7dfR200-R214): Configured the email backend settings, including host, port, TLS usage, and credentials.