### PR TITLE
Chore: Use Custom Pagination Logic

### DIFF
--- a/death_notes/pagination.py
+++ b/death_notes/pagination.py
@@ -1,0 +1,18 @@
+from urllib.parse import parse_qs, urlencode, urlparse
+
+from rest_framework.pagination import LimitOffsetPagination
+
+
+class CustomLimitOffsetPagination(LimitOffsetPagination):
+    def _format_link(self, url):
+        if not url:
+            return None
+        parsed_url = urlparse(url)
+        query_params = parse_qs(parsed_url.query)
+        return '?' + urlencode(query_params, doseq=True)
+
+    def get_next_link(self):
+        return self._format_link(super().get_next_link())
+
+    def get_previous_link(self):
+        return self._format_link(super().get_previous_link())

--- a/death_notes/settings.py
+++ b/death_notes/settings.py
@@ -118,7 +118,7 @@ REST_FRAMEWORK = {
         'rest_framework.filters.OrderingFilter',
         'rest_framework.filters.SearchFilter',
     ),
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'DEFAULT_PAGINATION_CLASS': 'death_notes.pagination.CustomLimitOffsetPagination',
     'PAGE_SIZE': 10,
 }
 


### PR DESCRIPTION
Instead of returning the full URL for `next` and `previous`, return only the query params.