### PR TITLE
Fix: Use User Interval for Final Word Scheduling

### DIFF
--- a/accounts/apps.py
+++ b/accounts/apps.py
@@ -4,3 +4,9 @@ from django.apps import AppConfig
 class AuthConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'accounts'
+
+    def ready(self):
+        # connect signals on app initialization
+        import accounts.signals  # noqa: F401
+
+        return super().ready()

--- a/accounts/signals.py
+++ b/accounts/signals.py
@@ -1,0 +1,20 @@
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+from accounts.models import User
+
+
+@receiver(pre_save, sender=User)
+def pre_save_user(sender, instance: User, **kwargs):
+    """Signal handler to store previous values of a User instance.
+
+    Args:
+        sender (_type_): The model class that sent the signal.
+        instance (User): The instance of User that triggered the signal.
+    """
+    if instance._state.adding:
+        # skip if the user is being created
+        return
+    # cache the previous value in the instance for comparison
+    previous = User.objects.only('interval').get(pk=instance.pk)
+    instance.__previous_interval = previous.interval

--- a/cron/signals.py
+++ b/cron/signals.py
@@ -4,6 +4,7 @@ from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
 from django.utils import timezone
 
+from accounts.models import User
 from cron.models import Job
 from web.constants import MESSAGE_TYPE_MAPPING
 from web.models import ActivityLog, Message
@@ -40,6 +41,35 @@ def update_jobs_on_checkin(sender, created: bool, instance: ActivityLog, **kwarg
     Job.objects.bulk_update(jobs, ['scheduled_at'])
 
 
+@receiver(post_save, sender=User)
+def update_jobs_on_interval_change(sender, created: bool, instance: User, **kwargs):
+    """Signal handler to update the scheduled time of jobs when a User instance's interval is changed.
+
+    Args:
+        sender (Type[Model]): The model class that sent the signal.
+        instance (User): The instance of User that triggered the signal.
+    """
+    if created or getattr(instance, '__previous_interval', None) == instance.interval:
+        return
+
+    # filter user's time capsule messages
+    jobs = (
+        Job.objects.only('scheduled_at', 'message__delay')
+        .select_related('message')
+        .filter(
+            message__type=Message.Type.FINAL_WORD,
+            message__user_id=instance.id,
+        )
+    )
+
+    delta = instance.interval - instance.__previous_interval
+    for job in jobs:
+        job.scheduled_at += timedelta(days=delta)
+
+    # bulk update the scheduled time of jobs without triggering signals
+    Job.objects.bulk_update(jobs, ['scheduled_at'])
+
+
 @receiver(post_save, sender=Message)
 def post_save_message(sender, created: bool, instance: Message, **kwargs):
     """Signal handler to create a Job instance when a Message instance is created.
@@ -54,7 +84,9 @@ def post_save_message(sender, created: bool, instance: Message, **kwargs):
         scheduled_at = (
             instance.scheduled_at
             if instance.type == Message.Type.TIME_CAPSULE
-            else timezone.now() + timedelta(days=instance.delay)
+            else timezone.now()
+            + timedelta(days=instance.delay)
+            + timedelta(days=instance.user.interval)
         )
         Job.objects.create(
             message=instance,
@@ -71,7 +103,11 @@ def post_save_message(sender, created: bool, instance: Message, **kwargs):
                 )
         elif instance.type == Message.Type.FINAL_WORD:
             if instance.delay != getattr(instance, '__previous_delay', None):
-                scheduled_at = timezone.now() + timedelta(days=instance.delay)
+                scheduled_at = (
+                    timezone.now()
+                    + timedelta(days=instance.delay)
+                    + timedelta(days=instance.user.interval)
+                )
                 Job.objects.filter(message_id=instance.id).update(
                     scheduled_at=scheduled_at
                 )

--- a/web/tests.py
+++ b/web/tests.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
-from django.db.models.signals import pre_save
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from django.utils.timezone import make_aware
@@ -39,7 +38,7 @@ class SignalTests(TestCase):
         )
         # When
         message.delay = 20
-        pre_save.send(sender=Message, instance=message)
+        message.save()
         # Then
         self.assertTrue(hasattr(message, '__previous_delay'))
         self.assertEqual(getattr(message, '__previous_delay'), 10)


### PR DESCRIPTION
I forgot about user interval when scheduling / updating jobs for `FINAL_WORD` messages.